### PR TITLE
Added subtitle support/UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # youtube-dl-qt
 
-[![Build Status](https://travis-ci.org/rrooij/youtube-dl-qt.svg?branch=master)](https://travis-ci.org/rrooij/youtube-dl-qt)
 [![License](https://img.shields.io/badge/License-GPLv3-red.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 Simple QT-frontend for [youtube-dl](https://rg3.github.io/youtube-dl/).
-
-![youtube-dl-qt](https://rrooij.github.io/youtube-dl-qt/img/ytdl-qt-screenshot.png)
 
 youtube-dl is able to download lots of videos from streaming sites, not only from YouTube.
 See [supported sites](https://rg3.github.io/youtube-dl/supportedsites.html).
@@ -15,9 +12,6 @@ See [supported sites](https://rg3.github.io/youtube-dl/supportedsites.html).
 ### GNU/Linux
 Check out the [requirements](#requirements). You can choose to compile the binary yourself or
 use the binary I compiled (found in Releases). Be sure to give the binary execution rights.
-
-#### Arch Linux
-youtube-dl-qt is available in the [AUR](https://aur.archlinux.org/packages/youtube-dl-qt-git/).
 
 ### Windows
 There is an executable installer for Windows found in the releases called `setup_windows.exe`.
@@ -65,7 +59,7 @@ I could be missing one. If this is the case, report an issue.
 
 First, clone the git repository.
 
-`clone git@github.com:rrooij/youtube-dl-qt.git`
+`clone git@github.com:ToCodeABluejay/youtube-dl-qt.git`
 
 Go into the directory:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,8 @@
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+    a.setApplicationName("Youtube Downloader");
+    a.setApplicationVersion("0.6");
     MainWindow w;
     w.show();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -67,8 +67,18 @@ void MainWindow::actionDownload()
         outputWindow->show();
         YoutubeDL ytdl;
 
+        /*Ignores warings
+            * good for systems without ffmpeg/avconv - otherwise download will stop
+            * also good for playlist downloads with forbidden addresses
+            as it will continue to download the rest of the playlist without stopping*/
+        ytdl.addArguments("-i");
+
         if (ui->checkBoxAudioOnly->isChecked()) {
             ytdl.setFormat("bestaudio");
+        }
+
+        if (ui->checkBoxSubtitles->isChecked()) {
+            ytdl.addArguments("--all-subs");
         }
 
         outputWindow->setYtdl(ytdl.getYtdl());

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -23,7 +23,11 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>ytdl-qt</string>
+   <string>Youtube Downloader</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../yt-dl-qt-rsrcs.qrc">
+    <normaloff>:/rsrcs/tools/youtube-dl-qt-icon.svg</normaloff>:/rsrcs/tools/youtube-dl-qt-icon.svg</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QFormLayout" name="formLayout">
@@ -104,6 +108,13 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QCheckBox" name="checkBoxSubtitles">
+         <property name="text">
+          <string>Fetch subtitles</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>
@@ -115,13 +126,15 @@
      <x>0</x>
      <y>0</y>
      <width>444</width>
-     <height>19</height>
+     <height>29</height>
     </rect>
    </property>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <resources/>
+ <resources>
+  <include location="../yt-dl-qt-rsrcs.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/youtubedl.cpp
+++ b/src/youtubedl.cpp
@@ -109,6 +109,11 @@ QProcess* YoutubeDL::getYtdl()
     return this->ytdl;
 }
 
+void YoutubeDL::addArguments(QString arg)
+{
+    this->arguments << arg;
+}
+
 void YoutubeDL::resetArguments()
 {
     this->arguments.clear();

--- a/src/youtubedl.h
+++ b/src/youtubedl.h
@@ -21,6 +21,7 @@ public:
     void startDownload(QString url, QString workingDirectory);
     QVector<MediaFormat> getFormats() const;
     void setFormats(const QVector<MediaFormat> &value);
+    void addArguments(QString arg);
 
 private:
     QStringList arguments;

--- a/tools/youtube-dl-qt.desktop
+++ b/tools/youtube-dl-qt.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Encoding=UTF-8
 Exec=/usr/bin/youtube-dl-qt
-Name=youtube-dl-qt
+Name=Youtube Downloader
 Comment=Media downloader for many streaming sites
 Icon=youtube-dl-qt-icon.svg
 Terminal=false

--- a/youtube-dl-qt.pro
+++ b/youtube-dl-qt.pro
@@ -39,3 +39,6 @@ FORMS    += \
     src/formatselectionwindow.ui \
     src/mainwindow.ui \
     src/outputwindow.ui
+
+RESOURCES += \
+    yt-dl-qt-rsrcs.qrc

--- a/yt-dl-qt-rsrcs.qrc
+++ b/yt-dl-qt-rsrcs.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/rsrcs">
+        <file>tools/youtube-dl-qt-icon.svg</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
I added a checkbox to allow users to automatically download subtitles that are linked to videos, and I also made a couple of UI improvements, including adding an application name, so it doesn't just say "ytdl-qt" when running, and added the same name to the MainWindow dialog. I also linked the .svg to the MainWindow. Finally, I added the argument "-i" to ignore errors when downloading. This allows for playlists with forbidden URLs to continue downloading the rest of the playlist without stopping. It also allows for downloads to continue on systems that don't have an ffmpeg/avconv backend. For example, I found out that this is needed on Fedora installations.